### PR TITLE
Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang AS builder
+ARG GOOGLE_VERSION=v1.2.3
+RUN mkdir /nonexistent && chmod 777 /nonexistent
+USER nobody:nogroup
+RUN git clone -b $GOOGLE_VERSION https://github.com/1268/google /go/google && \
+    cd /go/google/cmd/play && \
+    CGO_ENABLED=0 go build
+
+FROM alpine
+ARG UID=1000
+ARG GID=1000
+COPY --chown=0:0 --chmod=755 --from=builder /go/google/cmd/play/play /usr/local/bin
+RUN mkdir /google && \
+    chown "$UID:$GID" /google
+USER $UID:$GID
+WORKDIR /google
+ENTRYPOINT ["/usr/local/bin/play"]

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,25 @@ to bypass. Since Google Services Framework 5 (2014), Google uses bot-guard via
 JavaScript to protect the login. I do not know how to reverse that, and I did
 not find any implementations online.
 
+## Docker container
+
+### Building
+```bash
+docker build . -t "google:latest"
+```
+**NOTE**: it is possible to provide a `build-arg` for `UID` and `GID`, which will allow you to set UID and GID of your non-privileged user in your system, so that you can for example mount /data in the container and have I/O there.
+
+### Building a specific version
+```bash
+export VERSION=v1.2.3
+docker build . --build-arg "GOOGLE_VERSION=$VERSION" -t "google:$VERSION"
+```
+
+### Running the docker container
+```bash
+docker run -it --rm google
+```
+
 ## Contact
 
 <dl>


### PR DESCRIPTION
This pull requests adds a Dockerfile and some instructions in the README on how to build and use such container.
Containerization is useful not only to isolate the program from the OS running it, but also to ease the deployment of the program.